### PR TITLE
Replaced an implicit relative import in director.py by an explicit one.

### DIFF
--- a/cocos/director.py
+++ b/cocos/director.py
@@ -174,7 +174,7 @@ class DefaultHandler( object ):
             return True
 
         elif symbol == pyglet.window.key.I and (modifiers & pyglet.window.key.MOD_ACCEL):
-            from layer import PythonInterpreterLayer
+            from .layer import PythonInterpreterLayer
 
             if not director.show_interpreter:
                 if director.python_interpreter == None:


### PR DESCRIPTION
The implicit relative import does not work in python3, and therefore a cocos app would crash when Ctrl-i was pressed, instead of showing the interactive python console.
