### PR TITLE
fixing tmx color problem in py2.X

### DIFF
--- a/cocos/tiles.py
+++ b/cocos/tiles.py
@@ -1785,7 +1785,7 @@ class TmxObjectLayer(MapLayer):
 
     def _update_sprite_set(self):
         self._sprites = {}
-        color = self.color[:3] + [128]
+        color = tuple(self.color[:3] + [128])
         color_image = pyglet.image.SolidColorImagePattern(color)
         for cell in self.get_visible_cells():
             cx, cy = key = cell.origin[:2]


### PR DESCRIPTION
Hello,

I noticed in tiles.py, line 1789 that we call pyglet.image.SolidColorImagePattern(color) with color being a list.
But in pyglet, it seems that SolidColorImagePattern requires a tuple.

If we are under Python 2, we come in the function

```
def color_as_bytes(color):
    if sys.version.startswith('2'):
        return '%c%c%c%c' % color
    else:
        if len(color) != 4:
            raise TypeError("color is expected to have 4 components")
        return bytes(color)
```

and `'%c%c%c%c' % [128]*4` would produce an exception.

I guess the easy fix would be in tiles.py to have on line 1788
`color = tuple(self.color[:3] + [128])`
