### PR TITLE
HexCell properties should be extracted from the cell element

### DIFF
--- a/cocos/tiles.py
+++ b/cocos/tiles.py
@@ -648,7 +648,7 @@ def hexmap_factory(resource, tag):
                 tile = resource.get_resource(tile)
             else:
                 tile = None
-            properties = _handle_properties(tag)
+            properties = _handle_properties(cell)
             c.append(HexCell(i, j, height, properties, tile))
 
     properties = _handle_properties(tag)


### PR DESCRIPTION
Not from the map. If you compare with the other cell factory, this is how they are doing it. 

As it is right now it doesn't seem to work.