### PR TITLE
Issue #248 RectMapCollider, player sometimes stuck

### DIFF
--- a/cocos/tiles.py
+++ b/cocos/tiles.py
@@ -1147,10 +1147,10 @@ class RectMapCollider(object):
             # Correction on both axis
             if hasattr(cell, 'collide_later'):
                 if abs(dx_correction) < abs(dy_correction):
-                    # do correction only on x (below)
+                    # do correction only on X (below)
                     dy_correction = 0.0
                 elif abs(dy_correction) < abs(dx_correction):
-                     # do correction only on y (below)
+                     # do correction only on Y (below)
                     dx_correction = 0.0
                 else:
                     # let both corrections happen below
@@ -1176,36 +1176,6 @@ class RectMapCollider(object):
             else:
                 self.collide_top(dy)
         return dx, dy
-
-    def _collision_resolution_x(self, new, dx, dx_correction):
-        """Resolve the collision on the X axis.
-
-        Adjust new rect left position and dx velocity by dx_correction.
-        Calls the relevant method collide_left or collide_right.
-        Returns the modified dx.
-        """
-        new.left += dx_correction
-        dx += dx_correction
-        if dx_correction > 0.:
-            self.collide_left(dx)
-        else:
-            self.collide_right(dx)
-        return dx
-
-    def _collision_resolution_y(self, new, dy, dy_correction):
-        """Resolve the collision on the Y axis.
-
-        Adjust new rect top position and dy velocity by dy_correction.
-        Calls the relevant method collide_top or collide_bottom.
-        Returns the modified dy.
-        """
-        new.top += dy_correction
-        dy += dy_correction
-        if dy_correction > 0.:
-            self.collide_bottom(dy)
-        else:
-            self.collide_top(dy)
-        return dy
 
 
 class Cell(object):

--- a/cocos/tiles.py
+++ b/cocos/tiles.py
@@ -1058,8 +1058,6 @@ class RectMapCollider(object):
     """This class implements collisions between a moving rect object and a
     tilemap.
     """
-    resting = False
-
     def collide_bottom(self, dy):
         pass
 
@@ -1081,14 +1079,10 @@ class RectMapCollider(object):
 
         Returns the (possibly modified) (dx, dy)
         """
-        self.resting = False
         tested = set()
         cells = map.get_in_region(*(new.bottomleft + new.topright))
         for cell in cells:
             if cell is None or cell.tile is None or not cell.intersects(new):
-                continue
-            if cell in tested:
-                # don't re-test
                 continue
             tested.add(cell)
             dx, dy = self.do_collision(cell, last, new, dy, dx)

--- a/cocos/tiles.py
+++ b/cocos/tiles.py
@@ -1949,37 +1949,23 @@ class TmxObjectLayer(MapLayer):
 
 
 class TmxObjectMapCollider(RectMapCollider):
-    pass
+    def collide_map(self, map, last, new, dy, dx):
+        """Collide a rect with the given TmxObjectLayer map.
 
-    # QUESTION:
-    # Should we keep this code which is exactly the same as in RectMapCollider?
+        Apart from "map" the arguments are as per `do_collision`.
 
-    # def collide_map(self, map, last, new, dy, dx):
-    #     """Collide a rect with the given TmxObjectLayer map.
+        Mutates the new rect to conform with the map.
 
-    #     Apart from "map" the arguments are as per `do_collision`.
-
-    #     Mutates the new rect to conform with the map.
-
-    #     Returns the (possibly modified) (dx, dy)
-    #     """
-    #     self.resting = False
-    #     tested = set()
-    #     cells = map.get_in_region(*(new.bottomleft + new.topright))
-    #     for cell in cells:
-    #         if cell is None or cell.tile is None or not cell.intersects(new):
-    #             continue
-    #         # don't re-test
-    #         if cell in tested:
-    #             continue
-    #         tested.add(cell)
-    #         dx, dy = self.do_collision(cell, last, new, dy, dx)
-    #     cells_collide_later = [cell for cell in tested 
-    #                         if getattr(cell, 'collide_later', False) is True]
-    #     for cell in cells_collide_later:
-    #         if not cell.intersects(new):
-    #             continue
-    #         dx, dy = self.do_collision(cell, last, new, dy, dx)
-    #     for cell in cells_collide_later:
-    #         del cell.collide_later
-    #     return dx, dy
+        Returns the (possibly modified) (dx, dy)
+        """
+        self.resting = False
+        tested = set()
+        for cell in map.get_in_region(*(new.bottomleft + new.topright)):
+            if cell is None or cell.tile is None:
+                continue
+            # don't re-test
+            if cell in tested:
+                continue
+            tested.add(cell)
+            dx, dy = self.do_collision(cell, last, new, dy, dx)
+        return dx, dy

--- a/utest/aux_RectMapCollider__no_stuck.py
+++ b/utest/aux_RectMapCollider__no_stuck.py
@@ -71,53 +71,53 @@ def align_corner(rect, reference, corner):
 
 
 mapstrings = {    
-    'horizontal_no_hole': ( "o o o o o" +
-                            "o o o o o" +
-                            "x x x x x" +
-                            "o o o o o" +
-                            "o o o o o" +
+    'horizontal_no_hole': ( "o o o o o"
+                            "o o o o o"
+                            "x x x x x"
+                            "o o o o o"
+                            "o o o o o"
                             "o o o o o" ),
 
-    'horizontal_w_hole':  ( "o o o o o" +
-                            "o o o o o" +
-                            "x x o x x" +
-                            "o o o o o" +
-                            "o o o o o" +
+    'horizontal_w_hole':  ( "o o o o o"
+                            "o o o o o"
+                            "x x o x x"
+                            "o o o o o"
+                            "o o o o o"
                             "o o o o o" ),
 
-    'vertical_no_hole':   ( "o o x o o" +
-                            "o o x o o" +
-                            "o o x o o" +
-                            "o o x o o" +
-                            "o o x o o" +
+    'vertical_no_hole':   ( "o o x o o"
+                            "o o x o o"
+                            "o o x o o"
+                            "o o x o o"
+                            "o o x o o"
                             "o o x o o" ),
 
-    'vertical_w_hole':    ( "o o x o o" +
-                            "o o x o o" +
-                            "o o o o o" +
-                            "o o x o o" +
-                            "o o x o o" +
+    'vertical_w_hole':    ( "o o x o o"
+                            "o o x o o"
+                            "o o o o o"
+                            "o o x o o"
+                            "o o x o o"
                             "o o x o o" ),
 
-    'diagonal_gap_1':     ( "o o o o o" +
-                            "o o o o o" +
-                            "o x o o o" +
-                            "o o o x o" +
-                            "o o o o o" +
+    'diagonal_gap_1':     ( "o o o o o"
+                            "o o o o o"
+                            "o x o o o"
+                            "o o o x o"
+                            "o o o o o"
                             "o o o o o" ),
 
-    'diagonal_gap_2v':    ( "o o o o o" +
-                            "o o o o o" +
-                            "x o o o o" +
-                            "o o o x o" +
-                            "o o o o o" +
+    'diagonal_gap_2v':    ( "o o o o o"
+                            "o o o o o"
+                            "x o o o o"
+                            "o o o x o"
+                            "o o o o o"
                             "o o o o o" ),
 
-    'diagonal_gap_2h':    ( "o o o o o" +
-                            "o o o o o" +
-                            "o x o o o" +
-                            "o o o o o" +
-                            "o o o o o" +
+    'diagonal_gap_2h':    ( "o o o o o"
+                            "o o o o o"
+                            "o x o o o"
+                            "o o o o o"
+                            "o o o o o"
                             "o o o x o" ),
     }
 


### PR DESCRIPTION
Hello,

I've been thinking a bit about this problem. I'm sure physic engines have excellent solutions. Here is what I came up with. The basic idea is to say that for each cell we collide with, we only want to correct the new rect by the shortest distance possible. So if we find that we need to move it by 4 px in the X and by 2 px in the Y, we only move it by 2 px in the Y.
Now the only problem that is left is if we are positioned exactly on the diagonal and we find out that we should be moved by the same amount on the X and Y axis. In this case, we first don't correct anything with this cell, but we mark it with a special flag. We will come back to this cell after resolving all the other collisions. So we give the opportunity to the other cells which don't have this special positioning (being on the diagonal) to correct the new rect position correctly.

Once we're done with the collision resolutions, we take all the cells that were flagged, and we now see if we're still in the same situation. The situation might have changed if there were other cells which corrected the new rect position. 
But if are are still in the same situation, we now choose to move the new rect on both X and Y axis. We could have chosen an arbitrary axis instead.

Here is a proposition of this method.

Regards,
Daniel.