### PR TITLE
Cleanup travis.yml, add pypy, drop python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,24 @@
-# recycling the .travis.yml from other project, commented out things
-# we don't need ATM but may come handy later -
-#before_install:
-#  - sudo apt-get update
-#  - sudo apt-get --reinstall install -qq language-pack-en language-pack-es
 
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
+
+# For pypy versions, see https://github.com/pyenv/pyenv/tree/master/plugins/python-build/share/python-build
+python: 
+  - "pypy2.7-5.8.0"
+  - "pypy3.5-5.8.0"
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
+  
+cache:
+  - pip
+  - directories:
+    - $HOME/.pyenv_cache
 
 env:
-    - cocos_utest=1
+  - cocos_utest=1
 
 install:
-#  - "pip install -r requirements.txt --use-mirrors"
-#  - "pip install . --use-mirrors"
    - python setup.py install
 script:
-  - cd utest && py.test --tb native
+- cd utest && py.test --tb native


### PR DESCRIPTION
Added pypy - since all tests pass.
Added python 3.4, 3.5

Dropped python 3..3 - in the world of python 3, it is pretty old - a lot of the good things in python 3 came later (with many people saying 3.5 is the first really usable version)

Removed commented out code - there are plenty of examples around, so this is not needed.