### PR TITLE
PlayUntilFinishedAction

### DIFF
--- a/cocos/audio/actions.py
+++ b/cocos/audio/actions.py
@@ -48,3 +48,22 @@ class PlayAction(actions.InstantAction):
         # A shallow copy should be enough because sound effects are immutable
         # Also, we don't need to use the memo, because there can not be a cycle
         return PlayAction(self.sound)
+
+
+class PlayUntilFinishedAction(actions.IntervalAction):
+    def init(self, sound):
+        self.sound = sound
+        self.duration = self.sound.get_length()
+
+    def start(self):
+        if audio._working:
+            self.sound.play()
+
+    def stop(self):
+        if audio._working:
+            self.sound.stop()
+
+    def __deepcopy__(self, memo):
+        # A shallow copy should be enough because sound effects are immutable
+        # Also, we don't need to use the memo, because there can not be a cycle
+        return PlayUntilFinishedAction(self.sound)

--- a/cocos/audio/effect.py
+++ b/cocos/audio/effect.py
@@ -73,3 +73,6 @@ class Effect(object):
     def play(self):
         if audio._working:
             self.sound.play()
+
+    def get_length(self):
+        return self.sound.get_length()

--- a/cocos/audio/effect.py
+++ b/cocos/audio/effect.py
@@ -74,5 +74,9 @@ class Effect(object):
         if audio._working:
             self.sound.play()
 
+    def stop(self):
+        if audio._working:
+            self.sound.stop()
+
     def get_length(self):
         return self.sound.get_length()


### PR DESCRIPTION
This PR adds `PlayUntilFinishedAction` to the `cocos.audio.actions` package. As the name states, it's an `IntervalAction` that doesn't report itself to be done until the sound actually finishes. This is extremely useful for doing actions upon the end of a sound effect.

A real-world example of its utility is in my own project, cinche, where it's already being used [here](https://github.com/anodium/cinche/blob/20a9836000bb14a9c21d73d7a7722b80d37f4243/cinche/title.py#L47-L49) to transition to a new scene the moment the sound effect stops playing.