### PR TITLE
Allow non-graphical testing of CocosNodes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,9 @@
 v0.6.8 - December ?, 2019
 
   - fixed ColorLayer crash when changing colors, #330, thanks MartinHowarth
-  - unpinned pyglet version, they are releasing fast. accept >= 1.4.9, < 2 
+  - unpinned pyglet version, they are releasing fast. accept >= 1.4.9, < 2
+  - make the Camera lazily evaluated in CocosNodes to allow creation of them without
+      the director being initialised.
   
 v0.6.7 - September 6, 2019 
 

--- a/cocos/cocosnode.py
+++ b/cocos/cocosnode.py
@@ -133,7 +133,11 @@ class CocosNode(object):
         #:
         #: You can change the camera manually or by using the 
         #: :class:`.Camera3DAction` action.
-        self.camera = Camera()
+        #
+        # The camera is created lazily so that a CocosNode can be instantiated without the
+        # director being initialised. This allows for non-graphical testing of the CocosNode
+        # functionality.
+        self._camera = None
 
         #: offset from (x,0) from where rotation and scale will be applied.
         #: Default: 0
@@ -173,6 +177,17 @@ class CocosNode(object):
         self.transform_matrix = euclid.Matrix3().identity()
         self.is_inverse_transform_dirty = False
         self.inverse_transform_matrix = euclid.Matrix3().identity()
+
+    @property
+    def camera(self):
+        """Provide access to the camera lazily."""
+        if self._camera is None:
+            self._camera = Camera()
+        return self._camera
+
+    @camera.setter
+    def camera(self, value):
+        self._camera = value
 
     def make_property(attr):
         types = {'anchor_x': "int", 'anchor_y': "int", "anchor": "(int, int)"}


### PR DESCRIPTION
Fixes #331.

Allow CocosNode to be created with the director being initialised to allow non-gui testing of cocosnode functionality (and subclasses).

Do this by making the Camera lazily evaluated.