### PR TITLE
Fix typehint for Scene constructor

### DIFF
--- a/cocos/scene.py
+++ b/cocos/scene.py
@@ -62,7 +62,7 @@ class Scene(cocosnode.CocosNode):
             music playback.
 
         Arguments:
-            children (list[Layer or Scene]):
+            children (union[Layer or Scene]):
                 Layers or Scenes that will be part of the scene.
                 They are automatically assigned a z-level from 0 to
                 num_children.


### PR DESCRIPTION
The typehinting for the Scene constructor asks for a list to be passed in, but the function actually needs separate argumens passed into the *children parameter. This results in linter complaints when using the proper usage, and code not running if you adhere to the linter complaints.