### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/benchmarks/collision/compare_collisions.py
+++ b/benchmarks/collision/compare_collisions.py
@@ -19,7 +19,7 @@ import pprint
 import a0_benchmark_time_per_frame as cmark 
 
 # --> specify comparison variants
-# each variant is a dict specifing the cases to compare
+# each variant is a dict specifying the cases to compare
 
 # how to specify cases ('placeholder' would be replaced with implementation_shortname
 ##cases = {

--- a/cocos/actions/base_actions.py
+++ b/cocos/actions/base_actions.py
@@ -421,7 +421,7 @@ class Action(object):
 
     def init(*args, **kwargs):
         """
-        Gets called by __init__ with all the parameteres received,
+        Gets called by __init__ with all the parameters received,
         At this time the target for the action is unknown.
         Typical use is store parameters needed by the action.
         """

--- a/cocos/actions/instant_actions.py
+++ b/cocos/actions/instant_actions.py
@@ -148,7 +148,7 @@ class CallFunc(InstantAction):
 
 
 class CallFuncS(CallFunc):
-    """An action that will call a funtion with the target as the first argument
+    """An action that will call a function with the target as the first argument
 
     Example::
 

--- a/cocos/audio/pygame/mixer.py
+++ b/cocos/audio/pygame/mixer.py
@@ -4,7 +4,7 @@
 
 This module contains classes for loading Sound objects and controlling
 playback. The mixer module is optional and depends on SDL_mixer. Your
-program should test that pygame.mixer is available and intialized before
+program should test that pygame.mixer is available and initialized before
 using it.
 
 The mixer module has a limited number of channels for playback of sounds.

--- a/cocos/cocosnode.py
+++ b/cocos/cocosnode.py
@@ -241,7 +241,7 @@ class CocosNode(object):
         The callback function prototype is the same as for :meth:`schedule`.
 
         This function is a wrapper to ``pyglet.clock.schedule_interval``.
-        It has the additional benefit that all calllbacks are paused and
+        It has the additional benefit that all callbacks are paused and
         resumed when the node leaves or enters a scene.
 
         You should not have to schedule things using pyglet by yourself.
@@ -274,7 +274,7 @@ class CocosNode(object):
                 pass
 
         This function is a wrapper to ``pyglet.clock.schedule``.
-        It has the additional benefit that all calllbacks are paused and
+        It has the additional benefit that all callbacks are paused and
         resumed when the node leaves or enters a scene.
 
         You should not have to schedule things using pyglet by yourself.
@@ -299,7 +299,7 @@ class CocosNode(object):
         are removed. If the function was not scheduled, no error is raised.
 
         This function is a wrapper to pyglet.clock.unschedule.
-        It has the additional benefit that all calllbacks are paused and
+        It has the additional benefit that all callbacks are paused and
         resumed when the node leaves or enters a scene.
 
         You should not unschedule things using pyglet that where scheduled

--- a/cocos/custom_clocks.py
+++ b/cocos/custom_clocks.py
@@ -170,13 +170,13 @@ class ScreenReaderClock(pyglet.clock.Clock):
         self.last_ts = ts
 
         # Call functions scheduled for every frame
-        # Dupe list just in case one of the items unchedules itself
+        # Dupe list just in case one of the items unschedules itself
         for item in list(self._schedule_items):
             item.func(delta_t, *item.args, **item.kwargs)
 
         # Call all scheduled interval functions and reschedule for future.
         need_resort = False
-        # Dupe list just in case one of the items unchedules itself
+        # Dupe list just in case one of the items unschedules itself
         for item in list(self._schedule_interval_items):
             if item.next_ts > ts:
                 break
@@ -329,13 +329,13 @@ class AutotestClock(pyglet.clock.Clock):
         self.last_ts = ts
 
         # Call functions scheduled for every frame
-        # Dupe list just in case one of the items unchedules itself
+        # Dupe list just in case one of the items unschedules itself
         for item in list(self._schedule_items):
             item.func(delta_t, *item.args, **item.kwargs)
 
         # Call all scheduled interval functions and reschedule for future.
         need_resort = False
-        # Dupe list just in case one of the items unchedules itself
+        # Dupe list just in case one of the items unschedules itself
         for item in list(self._schedule_interval_items):
             if item.next_ts > ts:
                 break

--- a/cocos/mapcolliders.py
+++ b/cocos/mapcolliders.py
@@ -242,7 +242,7 @@ class RectMapCollider(object):
             new (Rect) : tentative actor's rect after step
 
         Decides if there is a collision with obj when moving ``last`` -> ``new``
-        and then returns the minimal correctioin in each axis as to not collide.
+        and then returns the minimal correction in each axis as to not collide.
         
         It can be overridden to be more selective about when a collision exists
         (see the matching method in :class:`RectMapWithPropsCollider` for example).

--- a/cocos/particle.py
+++ b/cocos/particle.py
@@ -52,7 +52,7 @@ from cocos.director import director
 from cocos.shader import ShaderProgram
 
 # for dev and diagnostic, None means real automatic, True / False means
-# return this value inconditionally
+# return this value unconditionally
 forced_point_sprites = None
 
 
@@ -61,7 +61,7 @@ def point_sprites_available():
     Returns:
         bool: tells if ``point sprites`` are available.
 
-    For development and diagonostic :class:`cocos.particle.forced_point_sprites`
+    For development and diagnostic :class:`cocos.particle.forced_point_sprites`
     could be set to force the desired return value.
     """
     if forced_point_sprites is not None:

--- a/cocos/skeleton.py
+++ b/cocos/skeleton.py
@@ -372,7 +372,7 @@ class Animation(object):
             who.pose_from(prev)
             return
 
-        # we find the dt betwen prev and next and pose from it
+        # we find the dt between prev and next and pose from it
         ft = (nt-dt) / (nt-pt)
 
         who.pose_from(next.interpolated_to(prev, ft))

--- a/cocos/text.py
+++ b/cocos/text.py
@@ -95,7 +95,7 @@ class Label(TextElement):
 
     Functionality other that the one common to all cococsnodes, except 'opacity', is
     provided by the member 'element' , which is the underlying pyglet object.
-    The undelying pyglet object is pyglet.text.Label
+    The underlying pyglet object is pyglet.text.Label
 
     For pyglet 1.1.4 the available init keyword arguments are
         - font_name: Font family name(s); the first matching name is used
@@ -120,7 +120,7 @@ class HTMLLabel(TextElement):
 
     Functionality other that the one common to all cococsnodes, except 'opacity', is
     provided by the member 'element' , which is the underlying pyglet object.
-    The undelying pyglet object is pyglet.text.HTMLLabel.
+    The underlying pyglet object is pyglet.text.HTMLLabel.
 
     For pyglet 1.1.4 the available init keyword arguments are
         - location: Location object for loading images referred to in the document. By default, the working directory is used.
@@ -218,7 +218,7 @@ class PygletRichLabel(pyglet.text.DocumentLabel):
 class RichLabel(TextElement):
     """displays pyglet attributed (rich) text
 
-    The undelying pyglet object is a custom, cocos provided PygletRichLabel
+    The underlying pyglet object is a custom, cocos provided PygletRichLabel
     element, subclass of pyglet.text.DocumentLabel.
 
     For pyglet 1.1.4 the available init keyword arguments are

--- a/samples/jumping_lens.py
+++ b/samples/jumping_lens.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
     #  lens_effect: 0.7, a strong "lens". 0 means no effect at all. 1 means very strong
     #  center: center of the lens
     #  grid=(20,16): create a grid of 20 tiles x 16 tiles. More tiles will
-    #     look better but the performance will decraese
+    #     look better but the performance will decrease
     #  duration=10: 10 seconds
     lens = Lens3D(radius=150, lens_effect=0.7, center=(150, 150), grid=(20, 16), duration=50)
 

--- a/samples/mouse_elastic_box_selection.py
+++ b/samples/mouse_elastic_box_selection.py
@@ -480,7 +480,7 @@ class EditLayer(cocos.layer.Layer):
         # how-to update collman: remove/add vs clear/add all
         # when total number of actors is low anyone will be fine,
         # with high numbers, most probably we move only a small fraction
-        # For simplicity I choose remove/add, albeit a hybrid aproach
+        # For simplicity I choose remove/add, albeit a hybrid approach
         # can be implemented later
         self.set_selection_in_collman(False)
 #        print "begin drag: drag_selecting, drag_moving", self.drag_selecting, self.drag_moving

--- a/test/test_shader_examples.py
+++ b/test/test_shader_examples.py
@@ -142,7 +142,7 @@ class ProgramUntexturedFixedHardcodedColor(shader.ShaderProgram):
     Texture info, like texture coords in each vertex or actual active textures
     is ignored.
 
-    Any color info except the harcoded color is ignored.
+    Any color info except the hardcoded color is ignored.
 
     gl_FragColor is a predefined output variable for fragment shaders; it must
     be set in the fragment code or the object will be invisible.

--- a/utest/aux_RectMapCollider__no_stuck.py
+++ b/utest/aux_RectMapCollider__no_stuck.py
@@ -15,7 +15,7 @@ Implementation description
       case generator approach was selected
           - base cases depict qualitative diferent situations as a
              (map, actor_rect, push, signed free axis vector)
-          - for each parametrizable value , a set of values of
+          - for each parameterizable value , a set of values of
             interest is defined
           - code will walk the (base cases, params values) generating the
             concrete cases to validate
@@ -25,7 +25,7 @@ Implementation description
         map: the basic form and orientation in the situation
         cell_size, actor_size: mostly
            actor side z <=> cell side z
-           actor side odd or even (because .center assings; division_errors?)
+           actor side odd or even (because .center assigns; division_errors?)
         push style: dx, dy
         actor start position: move the start position along the wall to cover
           all int alignements with the grid, ie do offsets 1..cell_width if

--- a/utest/test_RectMapCollider__no_stuck.py
+++ b/utest/test_RectMapCollider__no_stuck.py
@@ -15,7 +15,7 @@ Implementation description
       case generator approach was selected
           - base cases depict qualitative diferent situations as a
              (map, actor_rect, push, signed free axis vector)
-          - for each parametrizable value , a set of values of
+          - for each parameterizable value , a set of values of
             interest is defined
           - code will walk the (base cases, params values) generating the
             concrete cases to validate
@@ -25,7 +25,7 @@ Implementation description
         map: the basic form and orientation in the situation
         cell_size, actor_size: mostly
            actor side z <=> cell side z
-           actor side odd or even (because .center assings; division_errors?)
+           actor side odd or even (because .center assigns; division_errors?)
         push style: dx, dy
         actor start position: move the start position along the wall to cover
           all int alignements with the grid, ie do offsets 1..cell_width if


### PR DESCRIPTION
There are small typos in:
- benchmarks/collision/compare_collisions.py
- cocos/actions/base_actions.py
- cocos/actions/instant_actions.py
- cocos/audio/pygame/mixer.py
- cocos/cocosnode.py
- cocos/custom_clocks.py
- cocos/mapcolliders.py
- cocos/particle.py
- cocos/skeleton.py
- cocos/text.py
- samples/jumping_lens.py
- samples/mouse_elastic_box_selection.py
- test/test_shader_examples.py
- utest/aux_RectMapCollider__no_stuck.py
- utest/test_RectMapCollider__no_stuck.py

Fixes:
- Should read `unschedules` rather than `unchedules`.
- Should read `underlying` rather than `undelying`.
- Should read `callbacks` rather than `calllbacks`.
- Should read `parameterizable` rather than `parametrizable`.
- Should read `assigns` rather than `assings`.
- Should read `unconditionally` rather than `inconditionally`.
- Should read `specifying` rather than `specifing`.
- Should read `parameters` rather than `parameteres`.
- Should read `initialized` rather than `intialized`.
- Should read `hardcoded` rather than `harcoded`.
- Should read `function` rather than `funtion`.
- Should read `diagnostic` rather than `diagonostic`.
- Should read `decrease` rather than `decraese`.
- Should read `correction` rather than `correctioin`.
- Should read `between` rather than `betwen`.
- Should read `approach` rather than `aproach`.

Closes #344