### PR TITLE
Remove deprecated 'rU' flag for open(...)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ from setuptools import setup, find_packages
 
 import os
 
-f = open('README.rst','rU')
+f = open('README.rst','r')
 long_description = f.read()
 f.close()
 


### PR DESCRIPTION
The 'rU' tag is deprecated as shown in the [Python documentation](https://docs.python.org/3.5/library/functions.html#open), and hence we can replace 'rU' with 'r'.